### PR TITLE
Added ability to set `serialNumber` in Homebridge config (in UI also)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Javascript and Typescript are not my main languages -- pointers, tips, and input
 ## Installation
 1. This is a plugin for Homebridge, so you'll need to install [homebridge](https://github.com/homebridge/homebridge) if you haven't already.  Be sure to install Node and NPM as well.
 2. Install the plugin using NPM: `sudo npm install -g homebridge-cec-tv-control`
+    * (Unless in `hb-shell` environment, then type `hb-service add homebridge-cec-tv-control` instead).
 3. Install the `cec-utils` package if the `cec-client` command is not present in your terminal: `sudo apt-get install cec-utils`
 * Additionally, cec-utils might not be available based on what distribution you're using.  You can also search for libCEC, as that might be packaged and available in your package manager.
 * On Raspberry Pi's OSMC image, `cec-cilent` is present at `/usr/osmc/bin/cec-client-4.0.2`, you'll need to run `sudo ln -s /usr/osmc/bin/cec-client-4.0.2 /usr/bin/cec-client` to link it to the default `$PATH` 
@@ -27,6 +28,8 @@ platforms": [
         "name": "CEC TV",
         "manufacturer": "TVMaker",
         "model": "Best",
+        "serialNumber": "CECTV01",
+        "firmwareRevision": "1.0",
         "pollingInterval": 2500,
         "minimizeLogging": false,
         "inputs": [
@@ -58,6 +61,8 @@ platforms": [
 * `name` - The name that you'd like to show up in Homekit.
 * `manufacturer` - The manufacturer name that you'd like to show up in the device information in Homekit.
 * `model` - The model name that you'd like to show up in the device information in Homekit.
+* `serialNumber` - The serial number that you'd like to show up in Homekit. Best to set to prevent errors with duplicate serials. Can be anything, and should be unique.
+* `firmwareRevision` - The firmware version that you'd like to show up in Homekit. Can be anything. Default is N/A
 * `pollingInterval` - **[Required]** This dictates how often the platform will try to query the HDMI-CEC device for its status.  This helps keep things in sync in Homekit if other devices (remotes, other CEC-enabled devices) change your device status.  This value is in milliseconds, so the default 2500 equates to 2.5 seconds.
 * `minimizeLogging` - The plugin periodically logs "informational" data when device status is changed, or polled.  If this is true, those logs will be suppressed.
 * `inputs` - A list of the HDMI inputs supported by your device.  Most TVs shouldn't let you switch to unused HDMI inputs (i.e. with nothing plugged in) so you only need to include inputs that are in-use (i.e. with something plugged into them).  

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ platforms": [
 * `name` - The name that you'd like to show up in Homekit.
 * `manufacturer` - The manufacturer name that you'd like to show up in the device information in Homekit.
 * `model` - The model name that you'd like to show up in the device information in Homekit.
-* `serialNumber` - The serial number that you'd like to show up in Homekit. Best to set to prevent errors with duplicate serials. Can be anything, and should be unique.
-* `firmwareRevision` - The firmware version that you'd like to show up in Homekit. Can be anything. Default is N/A
+* `serialNumber` - The serial number that you'd like to show up in Homekit. It is best to set this to prevent errors with duplicate serial numbers. Can be anything, and should be unique. Default is N/A.
+* `firmwareRevision` - The firmware version that you'd like to show up in Homekit. Can be anything. Default is N/A.
 * `pollingInterval` - **[Required]** This dictates how often the platform will try to query the HDMI-CEC device for its status.  This helps keep things in sync in Homekit if other devices (remotes, other CEC-enabled devices) change your device status.  This value is in milliseconds, so the default 2500 equates to 2.5 seconds.
 * `minimizeLogging` - The plugin periodically logs "informational" data when device status is changed, or polled.  If this is true, those logs will be suppressed.
 * `inputs` - A list of the HDMI inputs supported by your device.  Most TVs shouldn't let you switch to unused HDMI inputs (i.e. with nothing plugged in) so you only need to include inputs that are in-use (i.e. with something plugged into them).  

--- a/config.schema.json
+++ b/config.schema.json
@@ -28,8 +28,14 @@
       "serialNumber": {
         "title": "Serial Number",
         "type": "string",
-        "default": "DEFAULT SN",
+        "default": "N/A",
         "description": "This is the serial number of your TV.  This isn't required, but it will be added to the accessory information in Homekit."
+      },
+      "firmwareRevision": {
+        "title": "Firmware Revision",
+        "type": "string",
+        "default": "N/A",
+        "description": "This is the firmware version of your TV.  This isn't required, but it will be added to the accessory information in Homekit."
       },
       "pollingInterval": {
         "title": "Polling Interval",

--- a/config.schema.json
+++ b/config.schema.json
@@ -25,6 +25,12 @@
         "default": "N/A",
         "description": "This is the model of your TV.  This isn't required, but it will be added to the accessory information in Homekit."
       },
+      "serialNumber": {
+        "title": "Serial Number",
+        "type": "string",
+        "default": "DEFAULT SN",
+        "description": "This is the serial number of your TV.  This isn't required, but it will be added to the accessory information in Homekit."
+      },
       "pollingInterval": {
         "title": "Polling Interval",
         "type": "integer",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge CEC TV Control",
   "name": "homebridge-cec-tv-control",
-  "version": "0.1.18.1",
+  "version": "0.1.18",
   "description": "Provides a Homebridge Platform for controlling a connected HDMI device via CEC commands.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge CEC TV Control",
   "name": "homebridge-cec-tv-control",
-  "version": "0.1.18",
+  "version": "0.1.18.1",
   "description": "Provides a Homebridge Platform for controlling a connected HDMI device via CEC commands.",
   "license": "MIT",
   "repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -277,7 +277,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
     const tvManufacturer = this.config.manufacturer || 'N/A';
     const tvModel = this.config.model || 'N/A';
     const tvSerialNumber = this.config.serialNumber || 'N/A';
-    const tvFirmwareRevision = this.config.firmwareRevision || 'N/A';
+    //const tvFirmwareRevision = this.config.firmwareRevision || 'N/A';
     const UUID = this.api.hap.uuid.generate(PLUGIN_NAME);    
     const tvAccessory = new api.platformAccessory(tvName, UUID);
 
@@ -292,7 +292,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
       ?.setCharacteristic(this.Characteristic.Manufacturer, tvManufacturer)
       .setCharacteristic(this.Characteristic.Model, tvModel)
       .setCharacteristic(this.Characteristic.SerialNumber, tvSerialNumber)
-      .setCharacteristic(this.Characteristic.FirmwareRevision, this.config.firmwareRevision);
+      .setCharacteristic(this.Characteristic.FirmwareRevision, 'N/A');
 
     //log firmware
     this.log.info(`Firmware Revision set to: ${tvFirmwareRevision}`);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -283,9 +283,6 @@ export class CECTVControl implements DynamicPlatformPlugin {
 
     tvAccessory.category = this.api.hap.Categories.TELEVISION;
 
-    //log firmware
-    this.log.info(`Firmware Revision: ${tvFirmwareRevision}`);
-
     //Set up the AccessoryInformation Service.
     //There isn't really any information to add right now, but it'll prevent Homekit from displaying "Default" entries.
     tvAccessory.getService(this.Service.AccessoryInformation)
@@ -294,9 +291,6 @@ export class CECTVControl implements DynamicPlatformPlugin {
       .setCharacteristic(this.Characteristic.SerialNumber, tvSerialNumber)
       .setCharacteristic(this.Characteristic.FirmwareRevision, tvFirmwareRevision);
 
-    //log firmware
-    this.log.info(`Firmware Revision set to: ${tvFirmwareRevision}`);
-    
     this.tvService = new this.Service.Television(tvName, 'tvService');
 
     this.tvService.setCharacteristic(this.Characteristic.ConfiguredName, tvName);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -284,7 +284,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
     tvAccessory.category = this.api.hap.Categories.TELEVISION;
 
     //Set up the AccessoryInformation Service.
-    //There isn't really any information to add right now, but it'll prevent Homekit from displaying "Default" entries.
+    //The information either comes from the config or the default value 'N/A' to prevent Homekit from displaying "Default" entries.
     tvAccessory.getService(this.Service.AccessoryInformation)
       ?.setCharacteristic(this.Characteristic.Manufacturer, tvManufacturer)
       .setCharacteristic(this.Characteristic.Model, tvModel)

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -282,6 +282,8 @@ export class CECTVControl implements DynamicPlatformPlugin {
     const tvAccessory = new api.platformAccessory(tvName, UUID);
 
     tvAccessory.category = this.api.hap.Categories.TELEVISION;
+
+    //log firmware
     this.log.debug(`Firmware Revision: ${tvFirmwareRevision}`);
 
     //Set up the AccessoryInformation Service.
@@ -292,6 +294,9 @@ export class CECTVControl implements DynamicPlatformPlugin {
       .setCharacteristic(this.Characteristic.SerialNumber, tvSerialNumber)
       .setCharacteristic(this.Characteristic.FirmwareRevision, tvFirmwareRevision);
 
+    //log firmware
+    this.log.debug(`Firmware Revision set to: ${tvFirmwareRevision}`);
+    
     this.tvService = new this.Service.Television(tvName, 'tvService');
 
     this.tvService.setCharacteristic(this.Characteristic.ConfiguredName, tvName);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -284,7 +284,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
     tvAccessory.category = this.api.hap.Categories.TELEVISION;
 
     //log firmware
-    this.log.debug(`Firmware Revision: ${tvFirmwareRevision}`);
+    this.log.info(`Firmware Revision: ${tvFirmwareRevision}`);
 
     //Set up the AccessoryInformation Service.
     //There isn't really any information to add right now, but it'll prevent Homekit from displaying "Default" entries.
@@ -295,7 +295,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
       .setCharacteristic(this.Characteristic.FirmwareRevision, this.config.firmwareRevision);
 
     //log firmware
-    this.log.debug(`Firmware Revision set to: ${tvFirmwareRevision}`);
+    this.log.info(`Firmware Revision set to: ${tvFirmwareRevision}`);
     
     this.tvService = new this.Service.Television(tvName, 'tvService');
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -276,7 +276,8 @@ export class CECTVControl implements DynamicPlatformPlugin {
     const tvName = this.config.name || 'CEC TV';
     const tvManufacturer = this.config.manufacturer || 'N/A';
     const tvModel = this.config.model || 'N/A';
-    const tvSerialNumber = this.config.serialNumber || 'DEFAULT SN';
+    const tvSerialNumber = this.config.serialNumber || 'N/A';
+    const tvFirmwareRevision = this.config.firmwareRevision || 'N/A';
     const UUID = this.api.hap.uuid.generate(PLUGIN_NAME);    
     const tvAccessory = new api.platformAccessory(tvName, UUID);
 
@@ -288,7 +289,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
       ?.setCharacteristic(this.Characteristic.Manufacturer, tvManufacturer)
       .setCharacteristic(this.Characteristic.Model, tvModel)
       .setCharacteristic(this.Characteristic.SerialNumber, tvSerialNumber)
-      .setCharacteristic(this.Characteristic.FirmwareRevision, '1.0');
+      .setCharacteristic(this.Characteristic.FirmwareRevision, tvFirmwareRevision);
 
     this.tvService = new this.Service.Television(tvName, 'tvService');
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -276,6 +276,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
     const tvName = this.config.name || 'CEC TV';
     const tvManufacturer = this.config.manufacturer || 'N/A';
     const tvModel = this.config.model || 'N/A';
+    const tvSerialNumber = this.config.serialNumber || 'DEFAULT SN';
     const UUID = this.api.hap.uuid.generate(PLUGIN_NAME);    
     const tvAccessory = new api.platformAccessory(tvName, UUID);
 
@@ -286,8 +287,8 @@ export class CECTVControl implements DynamicPlatformPlugin {
     tvAccessory.getService(this.Service.AccessoryInformation)
       ?.setCharacteristic(this.Characteristic.Manufacturer, tvManufacturer)
       .setCharacteristic(this.Characteristic.Model, tvModel)
-      .setCharacteristic(this.Characteristic.SerialNumber, 'N/A')
-      .setCharacteristic(this.Characteristic.FirmwareRevision, 'N/A');
+      .setCharacteristic(this.Characteristic.SerialNumber, tvSerialNumber)
+      .setCharacteristic(this.Characteristic.FirmwareRevision, '1.0');
 
     this.tvService = new this.Service.Television(tvName, 'tvService');
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -277,7 +277,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
     const tvManufacturer = this.config.manufacturer || 'N/A';
     const tvModel = this.config.model || 'N/A';
     const tvSerialNumber = this.config.serialNumber || 'N/A';
-    //const tvFirmwareRevision = this.config.firmwareRevision || 'N/A';
+    const tvFirmwareRevision = this.config.firmwareRevision || 'N/A';
     const UUID = this.api.hap.uuid.generate(PLUGIN_NAME);    
     const tvAccessory = new api.platformAccessory(tvName, UUID);
 
@@ -292,7 +292,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
       ?.setCharacteristic(this.Characteristic.Manufacturer, tvManufacturer)
       .setCharacteristic(this.Characteristic.Model, tvModel)
       .setCharacteristic(this.Characteristic.SerialNumber, tvSerialNumber)
-      .setCharacteristic(this.Characteristic.FirmwareRevision, 'N/A');
+      .setCharacteristic(this.Characteristic.FirmwareRevision, tvFirmwareRevision);
 
     //log firmware
     this.log.info(`Firmware Revision set to: ${tvFirmwareRevision}`);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -292,7 +292,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
       ?.setCharacteristic(this.Characteristic.Manufacturer, tvManufacturer)
       .setCharacteristic(this.Characteristic.Model, tvModel)
       .setCharacteristic(this.Characteristic.SerialNumber, tvSerialNumber)
-      .setCharacteristic(this.Characteristic.FirmwareRevision, tvFirmwareRevision);
+      .setCharacteristic(this.Characteristic.FirmwareRevision, this.config.firmwareRevision);
 
     //log firmware
     this.log.debug(`Firmware Revision set to: ${tvFirmwareRevision}`);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -282,6 +282,7 @@ export class CECTVControl implements DynamicPlatformPlugin {
     const tvAccessory = new api.platformAccessory(tvName, UUID);
 
     tvAccessory.category = this.api.hap.Categories.TELEVISION;
+    this.log.debug(`Firmware Revision: ${tvFirmwareRevision}`);
 
     //Set up the AccessoryInformation Service.
     //There isn't really any information to add right now, but it'll prevent Homekit from displaying "Default" entries.


### PR DESCRIPTION
It was bothering me to have N/A in the Serial Number spot, so I added the ability to specify one. You just need to increase the version number to push this update. It is tested working. 